### PR TITLE
Fix aspect ratio of images on 16:9 screens

### DIFF
--- a/templates/biketag1/css/main.css
+++ b/templates/biketag1/css/main.css
@@ -1803,15 +1803,13 @@ body.is-preload #footer {
   border-top-right-radius: 10px;
   border-top-left-radius: 10px;
   border: 1px floralwhite solid;
-  width: 640px;
-  max-width: 75vw;
+  max-width: 25vw;
   border-bottom: 0;
   border-top: 0;
   background-color: rgba(0, 0, 0, 0.7);
   padding: 0.5em;
   padding-top: 0.1em;
-  max-height: 50vh;
-  height: 100vh;
+  max-height: 100vh;
 }
 @media screen and (min-width: 737px) {
   .m-imgur-post .description {

--- a/templates/biketag1/css/main.css
+++ b/templates/biketag1/css/main.css
@@ -1803,7 +1803,7 @@ body.is-preload #footer {
   border-top-right-radius: 10px;
   border-top-left-radius: 10px;
   border: 1px floralwhite solid;
-  max-width: 25vw;
+  max-width: 75vw;
   border-bottom: 0;
   border-top: 0;
   background-color: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
Hard-coded heights and widths broke the aspect ratio on my laptop, changed it to only use max-width and max-height which fixes the aspect ration on my computer and shouldn't affect how phones behave. I don't have a dev environment set up and was only lightly tested using Chrome's inspect feature, highly recommend your own testing.