### PR TITLE
[Config]: add appName to sample.config.json

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -66,7 +66,7 @@
 	"supportedRegions": [
 		"portland"
 	],
-
+	"appName": "BikeTag",
 	"port": 80,
 	"debug": false
 }


### PR DESCRIPTION
Newbie here again. When I first set up the app I was running into this error. Adding appName to the config fixed it

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/5338872/95025421-a419ae80-0657-11eb-9f1e-2fb0e1d13fd0.png">