### PR TITLE
Fix queueAlbumHash key name

### DIFF
--- a/config/public.json
+++ b/config/public.json
@@ -6,6 +6,6 @@
     "content": true,
     "howToStory": true,
 
-    "imgur": ["albumHash", "queueHash", "imgurClientID"],
+    "imgur": ["albumHash", "queueAlbumHash", "imgurClientID"],
     "reddit": ["subreddit", "includeLeaderboardInRedditPost"]
 }


### PR DESCRIPTION
I don't think this is being used, but it's queueAlbumHash in
subdomains.json