### PR TITLE
Update links from pdx to portland subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ To allow anyone and everyone to play BikeTag! This site will ingest the Reddit p
 
 ![BikeTag Game](https://i.imgur.com/Vq7mweWm.png)
 
--   See most recent round of BikeTag, and an archive of past rounds: http://pdx.biketag.org
--   A modal to play the next round (provide matching and new BikeTag images, Mystery Location description, hint, and name): http://pdx.biketag.org/#tagit
+-   See most recent round of BikeTag, and an archive of past rounds: http://portland.biketag.org
+-   A modal to play the next round (provide matching and new BikeTag images, Mystery Location description, hint, and name): http://portland.biketag.org/#tagit
 -   See all archived rounds of Biketag: http://portland.biketag.org/?count=all
--   See an individual round of BikeTag with matching images: http://pdx.biketag.org/95
+-   See an individual round of BikeTag with matching images: http://portland.biketag.org/95
 
 # Contribute
 


### PR DESCRIPTION
Example links pointed to pdx.biketag.org which doesn't appear to be running anymore.